### PR TITLE
Fixing bugs in Nougat / Adding Intent Declaration

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -18,20 +18,22 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+		<provider
+	       android:name="android.support.v4.content.FileProvider"
+	       android:authorities="${applicationId}.fileprovider"
+	       android:exported="false"
+	       android:grantUriPermissions="true">
+	       <meta-data
+	           android:name="android.support.FILE_PROVIDER_PATHS"
+	           android:resource="@xml/provider_paths" />
+   		</provider>
+
     </application>
 
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
-    <provider
-       android:name="android.support.v4.content.FileProvider"
-       android:authorities="${applicationId}.fileprovider"
-       android:exported="false"
-       android:grantUriPermissions="true">
-       <meta-data
-           android:name="android.support.FILE_PROVIDER_PATHS"
-           android:resource="@xml/provider_paths" />
-   </provider>
+    
 
 </manifest>

--- a/src/com/lazydroid/autoupdateapk/AutoUpdateApk.java
+++ b/src/com/lazydroid/autoupdateapk/AutoUpdateApk.java
@@ -434,6 +434,8 @@ public class AutoUpdateApk extends Observable {
 			// bugfix for Android 7 (Nougat)
 			// only Android 7's PackageManager can install from FileProvider content://
 			// http://stackoverflow.com/a/39333203/2378095
+
+			Intent notificationIntent;
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
 				notificationIntent = new Intent(Intent.ACTION_INSTALL_PACKAGE );
 				notificationIntent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);


### PR DESCRIPTION
Moving <provider> into  activity.
Placing it outside causes a NullPointerException

Also initalising notificationIntent because it's uninitialised and
causes app to crash on update notification